### PR TITLE
Segmentation fault fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Once the .ntl document has been written, presumably once the lecture or meeting 
 This means that the user does not have to bother with manually formatting anything, during or after writing their notes.
 
 ## Alternative Parser
-Stephan Kreutzer has developed his own parser for NTL, which supports output to raw XML, HTML and PDF.  This project can be found [here](https://github.com/publishing-systems/ntml).
+Stephan Kreutzer has developed his own parser for NTL, which supports output to raw XML, HTML and PDF.  This project can be found [here](https://github.com/publishing-systems/ntl).
 
 ## Syntax
 More features may be added to the language, but the commands that have currently been established are shown below.

--- a/configure
+++ b/configure
@@ -1,0 +1,2 @@
+#!/bin/sh
+sudo apt-get install libpodofo-dev

--- a/main.cpp
+++ b/main.cpp
@@ -2,8 +2,8 @@
  * Copyright (c) 2017 Billy Carlyle
  *
  * This file is part of NTL.
- *  
- *   Ntl is free software: you can redistribute it and/or modify
+ *
+ *   NTL is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
  *   the Free Software Foundation, either version 3 of the License, or
  *   (at your option) any later version.
@@ -24,7 +24,6 @@
 #include <podofo/podofo.h>
 #include <vector>
 #include "parser.h"
-#include "render.h"
 using namespace PoDoFo;
 
 void PrintHelp(){
@@ -41,7 +40,7 @@ int main( int argc, char* argv[] ){
 		PrintHelp();
 		return -1;
 	}
-	if(argv[1] == "help"){
+	if(std::string(argv[1]) == "help"){
 		PrintHelp();
 		return -1;
 	}

--- a/makefile
+++ b/makefile
@@ -1,0 +1,40 @@
+# Copyright (C) 2017 Stephan Kreutzer
+#
+# This file is part of NTL.
+#
+# NTL is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# NTL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NTL.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+.PHONY: all clean
+
+
+
+all: ntl
+
+
+
+ntl: main.cpp parser.o render.o
+	g++ main.cpp -lpodofo parser.o render.o -o ntl -Wall -Werror
+
+parser.o: parser.h parser.cpp
+	g++ parser.cpp -c -Wall -Werror
+
+render.o: render.h render.cpp
+	g++ render.cpp -c -Wall -Werror
+
+clean:
+	rm -f ./ntl
+	rm -f ./render.o
+	rm -f ./parser.o

--- a/parser.cpp
+++ b/parser.cpp
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2017 Billy Carlyle
+ * Copyright (c) 2017 Billy Carlyle, Stephan Kreutzer
  *
  * This file is part of NTL.
- *  
- *   Ntl is free software: you can redistribute it and/or modify
+ *
+ *   NTL is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
  *   the Free Software Foundation, either version 3 of the License, or
  *   (at your option) any later version.
@@ -49,16 +49,17 @@ void parser(char* filePath, char* fileName){
 	ifstream inFile(filePath);
 	// Open input file
 	if(inFile.is_open()){
+		InitDocument(fileName);
 		while(getline(inFile,inLine)){
 			lines.push_back(inLine);
 			if(regex_search(inLine, matchTitle, titleEx)){
 				cout << "Title is " << matchTitle.str(1) << endl;
-				DrawTitle(matchTitle.str(1), fileName);
+				DrawTitle(matchTitle.str(1));
 			}else if(regex_search(inLine, matchDrawLine, lineEx)){
 				cout << "Line detected" << endl;
 			}else if(regex_search(inLine, matchListItem, listItemEx)){
 				cout << "Item: " << matchListItem.str(1) << endl;
-//				DrawListItem(matchListItem.str(1), fileName);
+				DrawListItem(matchListItem.str(1));
 			}else if(regex_search(inLine, matchHighlight, highlightEx)){
 				cout << "Highlighted text: " << matchHighlight.str(1) << endl;
 			}
@@ -72,6 +73,7 @@ void parser(char* filePath, char* fileName){
 		}
 		cout << words[0] << endl;
 		cout << words[2] << endl;
+		CloseDocument();
 		inFile.close();
 	}else{
 		cout << "Error loading file" << endl;

--- a/parser.h
+++ b/parser.h
@@ -2,8 +2,8 @@
  * Copyright (c) 2017 Billy Carlyle
  *
  * This file is part of NTL.
- *  
- *   Ntl is free software: you can redistribute it and/or modify
+ *
+ *   NTL is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
  *   the Free Software Foundation, either version 3 of the License, or
  *   (at your option) any later version.
@@ -18,13 +18,11 @@
  */
 
 #ifndef parser_h
-#pragma once
 #define parser_h
 #include <fstream>
 #include <iostream>
 #include <vector>
 #include <string>
-#include <podofo/podofo.h>
 
 void parser(char* filePath, char* fileName);
 extern std::vector<std::string> words;

--- a/render.h
+++ b/render.h
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2017 Billy Carlyle
+ * Copyright (c) 2017 Billy Carlyle, Stephan Kreutzer
  *
  * This file is part of NTL.
- *  
- *   Ntl is free software: you can redistribute it and/or modify
+ *
+ *   NTL is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
  *   the Free Software Foundation, either version 3 of the License, or
  *   (at your option) any later version.
@@ -18,7 +18,6 @@
  */
 
 #ifndef render_h
-#pragma once
 #define render_h
 #include <iostream>
 #include <ctime>
@@ -27,8 +26,9 @@
 #include <podofo/podofo.h>
 #include <vector>
 #include <string>
-#include "parser.h"
 
-void DrawTitle(std::string documentTitle, char* fileName);
-void DrawListItem(std::string listItem, char* fileName);
+int InitDocument(char* fileName);
+void DrawTitle(std::string documentTitle);
+void DrawListItem(std::string listItem);
+int CloseDocument();
 #endif


### PR DESCRIPTION
If a document gets closed, it will destroy all of its pages as they're not needed any more. The invalid pointers of the removed pages can't be used for/on/by a consecutive document.